### PR TITLE
rbd: use JNA LongByReference type to marshall C ssize_t type

### DIFF
--- a/src/main/java/com/ceph/rbd/jna/Rbd.java
+++ b/src/main/java/com/ceph/rbd/jna/Rbd.java
@@ -22,6 +22,7 @@ import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.ptr.LongByReference;
 import com.sun.jna.ptr.PointerByReference;
 
 public interface Rbd extends Library {
@@ -32,7 +33,7 @@ public interface Rbd extends Library {
     int rbd_create(Pointer io, String name, long size, IntByReference order);
     int rbd_create2(Pointer io, String name, long size, long features, IntByReference order);
     int rbd_create3(Pointer io, String name, long size, long features, IntByReference order, long stripe_unit, long stripe_count);
-    int rbd_list(Pointer io, byte[] names, IntByReference size);
+    int rbd_list(Pointer io, byte[] names, LongByReference size);
     int rbd_remove(Pointer io, String name);
     int rbd_rename(Pointer io, String srcname, String destname);
     int rbd_open_read_only(Pointer io, String name, Pointer image, String snap_name);
@@ -58,5 +59,5 @@ public interface Rbd extends Library {
     int rbd_resize(Pointer source_image, long size);
     int rbd_flatten(Pointer image);
     int rbd_snap_set(Pointer image, String snapname);
-    int rbd_list_children(Pointer image, byte[] pools, IntByReference pools_len, byte[] images, IntByReference images_len);
+    long rbd_list_children(Pointer image, byte[] pools, LongByReference pools_len, byte[] images, LongByReference images_len);
 }

--- a/src/test/java/com/ceph/rbd/TestRbd.java
+++ b/src/test/java/com/ceph/rbd/TestRbd.java
@@ -480,7 +480,17 @@ public final class TestRbd extends TestCase {
 				rbd.create(testImage + i, imageSize);
 			}
 
+			// List images without providing initial buffer size
 			List<String> imageList = Arrays.asList(rbd.list());
+			assertTrue("There were less than " + imageCount + " images in the pool", imageList.size() >= imageCount);
+
+			for (int i = 1; i <= imageCount; i++) {
+				assertTrue("Pool does not contain image testimage" + i, imageList.contains(testImage + i));
+			}
+			
+			// List images and provide initial buffer size
+			imageList = null;
+			imageList = Arrays.asList(rbd.list(testImage.length()));
 			assertTrue("There were less than " + imageCount + " images in the pool", imageList.size() >= imageCount);
 
 			for (int i = 1; i <= imageCount; i++) {
@@ -498,7 +508,7 @@ public final class TestRbd extends TestCase {
 			fail(e.getMessage() + ": " + e.getReturnValue());
 		}
 	}
-
+	
 	public void testListChildren() {
 		try {
 			Rados r = new Rados(this.id);


### PR DESCRIPTION
@wido, I replaced IntByReference with LongByReference in image listing and snap children listing functions. The reason behind the change is LongByReference maps more closely with ssize_t which is used by the underlying librbd functions (rbd_list and rbd_list_children). In addition, using IntByReference also throws off the librbd logic and results in a seg fault when the input byte buffer to rbd_list() is smaller than the required size.
