### PR TITLE
fixed http://tracker.ceph.com/issues/10432

### DIFF
--- a/src/main/java/com/ceph/rados/ListCtx.java
+++ b/src/main/java/com/ceph/rados/ListCtx.java
@@ -115,9 +115,6 @@ public class ListCtx {
      * @return the Array of ids (limit by size and by the last call to nextObjects)
      */
     public String[] getObjects() {
-        if (list == null) {
-            return null;
-        }
         return Arrays.copyOf(this.ids, this.size);
     }
     /**


### PR DESCRIPTION
I have no idea why it has to return null when ``list`` is null, but that will cause a problem when using listObjectsPartial(N) and the last iteration has less than N records. 

```
public int nextObjects(long skip) throws RadosException {
        if (list == null) {
            return 0;
        }
        Pointer entry = new Memory(Pointer.SIZE);
        long j = 0;
        while (j < skip && rados.rados_objects_list_next(list.getPointer(0), entry, null) == 0) {
            j++;
        }
        int i = 0;
        while (i < limit && rados.rados_objects_list_next(list.getPointer(0), entry, null) == 0) {
            ids[i] = entry.getPointer(0).getString(0);
            i++;
        }
        if (i < limit) {//line 95
            // closing it
            rados.rados_objects_list_close(list.getPointer(0));
            list = null;
        }
        this.size = i;
        return this.size;
    }
```
say there are 15 records, and using a batch size of 10, the first 10 records will return normally, and at the 2nd nextObjects call, at line 95 ``if (i < limit)``, ``i==5`` < ``limit==10``, and the list is closed and set to ``null``. And in the current code at ``nextObjects``, it return null when the ``list`` is null.