### PR TITLE
set of small cleanups

### DIFF
--- a/src/main/java/com/ceph/rados/Library.java
+++ b/src/main/java/com/ceph/rados/Library.java
@@ -23,6 +23,8 @@ import com.ceph.rados.jna.Rados;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 final class Library {
     final static Rados rados;
 
@@ -47,11 +49,7 @@ final class Library {
         assert (len != -1): "C-Strings must be \\0 terminated.";
 
         final byte[] data = ptr.getByteArray(0, (int)len);
-        try {
-            return new String(data, "utf-8");
-        } catch (java.io.UnsupportedEncodingException e) {
-            throw new RuntimeException("Rados problem: UTF-8 decoding error.", e);
-        }
+        return new String(data, UTF_8);
     }
 
     /**

--- a/src/main/java/com/ceph/rados/Rados.java
+++ b/src/main/java/com/ceph/rados/Rados.java
@@ -37,14 +37,14 @@ public class Rados extends RadosBase {
      * flags for ReadOp.operate and (maybe later) WriteOp.operate
      * See librados operate flags for more information
      */
-    public static int OPERATION_NOFLAG             = 0;
-    public static int OPERATION_BALANCE_READS      = 1;
-    public static int OPERATION_LOCALIZE_READS     = 2;
-    public static int OPERATION_ORDER_READS_WRITES = 4;
-    public static int OPERATION_IGNORE_CACHE       = 8;
-    public static int OPERATION_SKIPRWLOCKS        = 16;
-    public static int OPERATION_IGNORE_OVERLAY     = 32;
-    public static int OPERATION_FULL_TRY           = 64;
+    public static final int OPERATION_NOFLAG             = 0;
+    public static final int OPERATION_BALANCE_READS      = 1;
+    public static final int OPERATION_LOCALIZE_READS     = 2;
+    public static final int OPERATION_ORDER_READS_WRITES = 4;
+    public static final int OPERATION_IGNORE_CACHE       = 8;
+    public static final int OPERATION_SKIPRWLOCKS        = 16;
+    public static final int OPERATION_IGNORE_OVERLAY     = 32;
+    public static final int OPERATION_FULL_TRY           = 64;
 
     protected Pointer clusterPtr;
     private boolean connected;

--- a/src/main/java/com/ceph/rbd/Library.java
+++ b/src/main/java/com/ceph/rbd/Library.java
@@ -23,6 +23,8 @@ import com.ceph.rbd.jna.Rbd;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 final class Library {
     final static Rbd rbd;
 
@@ -47,11 +49,7 @@ final class Library {
         assert (len != -1): "C-Strings must be \\0 terminated.";
 
         final byte[] data = ptr.getByteArray(0, (int)len);
-        try {
-            return new String(data, "utf-8");
-        } catch (java.io.UnsupportedEncodingException e) {
-            throw new RuntimeException("Rbd problem: UTF-8 decoding error.", e);
-        }
+        return new String(data, UTF_8);
     }
 
     /**

--- a/src/main/java/com/ceph/rbd/Rbd.java
+++ b/src/main/java/com/ceph/rbd/Rbd.java
@@ -223,12 +223,7 @@ public class Rbd {
      * @return RbdImage
      */
     public RbdImage open(String name) throws RbdException {
-        Pointer p = new Memory(Pointer.SIZE);
-        int r = rbd.rbd_open(this.io, name, p, null);
-        if (r < 0) {
-            throw new RbdException("Failed to open image " + name, r);
-        }
-        return new RbdImage(p, name);
+        return this.open(name, null);
     }
 
     /**
@@ -259,12 +254,7 @@ public class Rbd {
      * @return RbdImage
      */
     public RbdImage openReadOnly(String name) throws RbdException {
-        Pointer p = new Memory(Pointer.SIZE);
-        int r = rbd.rbd_open_read_only(this.io, name, p, null);
-        if (r < 0) {
-            throw new RbdException("Failed to open image " + name, r);
-        }
-        return new RbdImage(p, name);
+        return this.openReadOnly(name, null);
     }
 
     /**


### PR DESCRIPTION
- jni: use StandardCharsets.UTF_8 when converting byte array to a String
- rbd: reduce code duplication
-  make constants final
