### PR TITLE
rados,rbd: make Rados/RbdException subclasses of IOException

### DIFF
--- a/src/main/java/com/ceph/rados/exceptions/RadosException.java
+++ b/src/main/java/com/ceph/rados/exceptions/RadosException.java
@@ -18,7 +18,9 @@
 
 package com.ceph.rados.exceptions;
 
-public class RadosException extends Exception {
+import java.io.IOException;
+
+public class RadosException extends IOException {
 
     protected int returnValue;
 

--- a/src/main/java/com/ceph/rbd/RbdException.java
+++ b/src/main/java/com/ceph/rbd/RbdException.java
@@ -18,7 +18,9 @@
 
 package com.ceph.rbd;
 
-public class RbdException extends Exception {
+import java.io.IOException;
+
+public class RbdException extends IOException {
 
     protected int returnValue;
 


### PR DESCRIPTION
as it's more natural to integrate rados operations into IO path.

Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
