### PR TITLE
Added support for Completions, AIO writes IOCtx namespaces, and a Maven option to skip unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,14 +73,14 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.10.3</version>
         </plugin>
-	    <plugin>
-	      <groupId>org.apache.maven.plugins</groupId>
-	      <artifactId>maven-surefire-plugin</artifactId>
-	      <version>2.19.1</version>
-	      <configuration>
-	      	<skipTests>${com.ceph.rados.skipTests}</skipTests>
-	      </configuration>
-	    </plugin>	
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.19.1</version>
+          <configuration>
+            <skipTests>${com.ceph.rados.skipTests}</skipTests>
+          </configuration>
+        </plugin>	
       </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <com.ceph.rados.skipTests>false</com.ceph.rados.skipTests>
     </properties>
 
     <build>
@@ -72,6 +73,14 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.10.3</version>
         </plugin>
+	    <plugin>
+	      <groupId>org.apache.maven.plugins</groupId>
+	      <artifactId>maven-surefire-plugin</artifactId>
+	      <version>2.19.1</version>
+	      <configuration>
+	      	<skipTests>${com.ceph.rados.skipTests}</skipTests>
+	      </configuration>
+	    </plugin>	
       </plugins>
     </build>
 

--- a/src/main/java/com/ceph/rados/Completion.java
+++ b/src/main/java/com/ceph/rados/Completion.java
@@ -14,198 +14,200 @@ import com.sun.jna.Pointer;
 import com.sun.jna.ptr.PointerByReference;
 
 public class Completion extends RadosBase implements Closeable {
-	// Static members
-	private static Map<Integer,Completion> completionMap = new HashMap<>();
-	private static int nextCompletionId = 1;
-	
-	// Instance members
-	private boolean safe;
-	private boolean complete;
-	
-	// Callback support
-	private static Callback completeCallback = new Callback() {
-		@SuppressWarnings("unused")
-		public void callback(Pointer completionPointer, Pointer callbackContext) throws RadosException {
-			final int completionId = (int)Pointer.nativeValue(callbackContext);
-			Completion completion;
-			synchronized (completionMap) {
-				completion = completionMap.get(completionId);
-			}
-			
-			// If the completion has not been closed yet, call the handler.
-			if (completion != null) {
-				completion.complete = true;
-				completion.onComplete();
-			}
-		}
-	};
-	private static Callback safeCallback = new Callback() {
-		@SuppressWarnings("unused")
-		public void callback(Pointer completionPointer, Pointer callbackContext) throws RadosException {
-			final int completionId = (int)Pointer.nativeValue(callbackContext);
-			Completion completion;
-			synchronized (completionMap) {
-				completion = completionMap.get(completionId);
-			}
+    // Static members
+    private static Map<Integer, Completion> completionMap = new HashMap<>();
+    private static int nextCompletionId = 1;
 
-			// If the completion has not been closed yet, call the handler.
-			if (completion != null) {
-				completion.safe = true;
-				completion.onSafe();
-			}
-		}
-	};
+    // Instance members
+    private boolean safe;
+    private boolean complete;
 
-	// Instance members
-	private Pointer pointer;
-	private int id;
-	
+    // Callback support
+    private static Callback completeCallback = new Callback() {
+        @SuppressWarnings("unused")
+        public void callback(Pointer completionPointer, Pointer callbackContext) throws RadosException {
+            final int completionId = (int) Pointer.nativeValue(callbackContext);
+            Completion completion;
+            synchronized (completionMap) {
+                completion = completionMap.get(completionId);
+            }
+
+            // If the completion has not been closed yet, call the handler.
+            if (completion != null) {
+                completion.complete = true;
+                completion.onComplete();
+            }
+        }
+    };
+    private static Callback safeCallback = new Callback() {
+        @SuppressWarnings("unused")
+        public void callback(Pointer completionPointer, Pointer callbackContext) throws RadosException {
+            final int completionId = (int) Pointer.nativeValue(callbackContext);
+            Completion completion;
+            synchronized (completionMap) {
+                completion = completionMap.get(completionId);
+            }
+
+            // If the completion has not been closed yet, call the handler.
+            if (completion != null) {
+                completion.safe = true;
+                completion.onSafe();
+            }
+        }
+    };
+
+    // Instance members
+    private Pointer pointer;
+    private int id;
+
     /**
      * Constructs a completion to use with asynchronous operations.
      * <p>
-     * The complete and safe callbacks correspond to operations being acked and committed, respectively.
-     * The callbacks are called in order of receipt, so the safe callback may be triggered before the complete callback, and vice versa.
-     * This is affected by journalling on the OSDs.
+     * The complete and safe callbacks correspond to operations being acked and
+     * committed, respectively. The callbacks are called in order of receipt, so
+     * the safe callback may be triggered before the complete callback, and vice
+     * versa. This is affected by journalling on the OSDs.
      * <p>
      * NOTE: Read operations only get a complete callback.
      * 
-	 * @param notifyOnComplete If true, onComplete() is called when the operation is in memory on all replicas
-	 * @param notifyOnSafe If true, onSafe() is called when the operation is on stable storage on all replicas
-     * @throws RadosException 
+     * @param notifyOnComplete
+     *            If true, onComplete() is called when the operation is in
+     *            memory on all replicas
+     * @param notifyOnSafe
+     *            If true, onSafe() is called when the operation is on stable
+     *            storage on all replicas
+     * @throws RadosException
      */
-	public Completion(final boolean notifyOnComplete, final boolean notifyOnSafe) throws RadosException {
-		super();
+    public Completion(final boolean notifyOnComplete, final boolean notifyOnSafe) throws RadosException {
+        super();
         final PointerByReference pointerByReference = new PointerByReference();
 
         // Generate an ID for this completion.
         synchronized (completionMap) {
-        	id = nextCompletionId++;
-        	if (id <= 0) {
-        		id = 1;
-        		nextCompletionId = 2;
-        	}
+            id = nextCompletionId++;
+            if (id <= 0) {
+                id = 1;
+                nextCompletionId = 2;
+            }
 
-        	// If callbacks will be registered, then also record this object in the global completion map 
-        	// so that it can be accessed from the callback handlers. 
-    		if (notifyOnComplete || notifyOnSafe)
-    			completionMap.put(id, this);
+            // If callbacks will be registered, then also record this object in
+            // the global completion map
+            // so that it can be accessed from the callback handlers.
+            if (notifyOnComplete || notifyOnSafe)
+                completionMap.put(id, this);
         }
-        
-        // Create the completion object.
-		if (notifyOnComplete || notifyOnSafe) {
-			handleReturnCode(new Callable<Integer>() {
-					@Override
-					public Integer call() throws Exception {
-						return rados.rados_aio_create_completion(
-								Pointer.createConstant((long)id), 
-								notifyOnComplete?completeCallback:null, 
-								notifyOnSafe?safeCallback:null,
-								pointerByReference
-						);
-					}
-				},
-				"Failed to create completion with callbacks"
-			);
-			
-		} else {
-			handleReturnCode(new Callable<Integer>() {
-					@Override
-					public Integer call() throws Exception {
-						return rados.rados_aio_create_completion(null, null, null, pointerByReference);
-					}
-				},
-				"Failed to create completion"
-			);
-		}
-        pointer = pointerByReference.getValue();
-	}
-	
-	/**
-	 * Block until the operation completes.  This means it is in memory on all replicas.
-	 * @throws RadosException
-	 */
-	public void waitForComplete() throws RadosException {
-        handleReturnCode(new Callable<Integer>() {
-	        	@Override
-	            public Integer call() throws Exception {
-	                return rados.rados_aio_wait_for_complete(getPointer());
-	            }
-	        },
-	        "Failed to wait for AIO completion"
-	    );		
-	}
 
-	/**
-	 * Override this function to implement callback handling.  If notifyOnSafe is true, this function is called when
-	 * the operation is in memory on all replicas. 
-	 */
-	public void onComplete() {
-	}
-	
-	/**
-	 * Override this function to implement callback handling.  If notifyOnComplete is true, this function is called when
-	 * the operation is on stable storage on all replicas. 
-	 */
-	public void onSafe() {
-	}
-	
+        // Create the completion object.
+        if (notifyOnComplete || notifyOnSafe) {
+            handleReturnCode(new Callable<Integer>() {
+                @Override
+                public Integer call() throws Exception {
+                    return rados.rados_aio_create_completion(Pointer.createConstant((long) id), notifyOnComplete ? completeCallback : null,
+                            notifyOnSafe ? safeCallback : null, pointerByReference);
+                }
+            }, "Failed to create completion with callbacks");
+
+        } else {
+            handleReturnCode(new Callable<Integer>() {
+                @Override
+                public Integer call() throws Exception {
+                    return rados.rados_aio_create_completion(null, null, null, pointerByReference);
+                }
+            }, "Failed to create completion");
+        }
+        pointer = pointerByReference.getValue();
+    }
+
+    /**
+     * Block until the operation completes. This means it is in memory on all
+     * replicas.
+     * 
+     * @throws RadosException
+     */
+    public void waitForComplete() throws RadosException {
+        handleReturnCode(new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                return rados.rados_aio_wait_for_complete(getPointer());
+            }
+        }, "Failed to wait for AIO completion");
+    }
+
+    /**
+     * Override this function to implement callback handling. If notifyOnSafe is
+     * true, this function is called when the operation is in memory on all
+     * replicas.
+     */
+    public void onComplete() {
+    }
+
+    /**
+     * Override this function to implement callback handling. If
+     * notifyOnComplete is true, this function is called when the operation is
+     * on stable storage on all replicas.
+     */
+    public void onSafe() {
+    }
+
     /**
      * Release a completion
      * <p>
-     * Call this when you no longer need the completion. It may not be freed immediately if the operation is not acked and committed.
+     * Call this when you no longer need the completion. It may not be freed
+     * immediately if the operation is not acked and committed.
      */
-	@Override
-	public void close() throws IOException {
-		rados.rados_aio_release(getPointer());
-		if (id > 0) {
-			synchronized (completionMap) {
-				completionMap.remove(id);
-			}
-			id = 0;
-		}
-	}
+    @Override
+    public void close() throws IOException {
+        rados.rados_aio_release(getPointer());
+        if (id > 0) {
+            synchronized (completionMap) {
+                completionMap.remove(id);
+            }
+            id = 0;
+        }
+    }
 
-	/**
-	 * @return A unique ID identifying the completion.
-	 */
-	public int getId() {
-		return id;
-	}
+    /**
+     * @return A unique ID identifying the completion.
+     */
+    public int getId() {
+        return id;
+    }
 
-	/**
-	 * @return True if the safe callback is enabled has occurred, else false.
-	 */
-	public boolean isSafe() {
-		return safe;
-	}
+    /**
+     * @return True if the safe callback is enabled has occurred, else false.
+     */
+    public boolean isSafe() {
+        return safe;
+    }
 
-	/**
-	 * @return True if the complete callback is enabled has occurred, else false.
-	 */
-	public boolean isComplete() {
-		return complete;
-	}
+    /**
+     * @return True if the complete callback is enabled has occurred, else
+     *         false.
+     */
+    public boolean isComplete() {
+        return complete;
+    }
 
-	public Pointer getPointer() {
-		return pointer;
-	}
+    public Pointer getPointer() {
+        return pointer;
+    }
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + id;
-		return result;
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + id;
+        return result;
+    }
 
-	@Override
-	public boolean equals(Object that) {
-		if (this == that)
-			return true;
-		if (that == null)
-			return false;
-		if (!(that instanceof Completion))
-			return false;
-		return (id == ((Completion)that).id);
-	}
+    @Override
+    public boolean equals(Object that) {
+        if (this == that)
+            return true;
+        if (that == null)
+            return false;
+        if (!(that instanceof Completion))
+            return false;
+        return (id == ((Completion) that).id);
+    }
 }

--- a/src/main/java/com/ceph/rados/Completion.java
+++ b/src/main/java/com/ceph/rados/Completion.java
@@ -1,0 +1,89 @@
+package com.ceph.rados;
+
+import static com.ceph.rados.Library.rados;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.Callable;
+
+import com.ceph.rados.exceptions.RadosException;
+import com.sun.jna.Callback;
+import com.sun.jna.Pointer;
+import com.sun.jna.ptr.PointerByReference;
+
+public class Completion extends RadosBase implements Closeable {
+	private Pointer pointer;
+	
+    /**
+     * Constructs a completion to use with asynchronous operations.
+     * <p>
+     * The complete and safe callbacks correspond to operations being acked and committed, respectively.
+     * The callbacks are called in order of receipt, so the safe callback may be triggered before the complete callback, and vice versa.
+     * This is affected by journalling on the OSDs.
+     * <p>
+     * NOTE: Read operations only get a complete callback.
+     * 
+     * @param callbackContext application-defined data passed to the callback functions
+     * @param callbackComplete the function to be called when the operation is in memory on all replicas
+     * @param callbackSafe the function to be called when the operation is on stable storage on all replicas
+     * @param pointer where to store the completion
+     * @return 0
+     * @throws RadosException 
+     */
+	public Completion(final Pointer callbackContext, final Callback callbackComplete, final Callback callbackSafe) throws RadosException {
+		super();
+        final PointerByReference pointerByReference = new PointerByReference();
+        handleReturnCode(new Callable<Integer>() {
+	            @Override
+	            public Integer call() throws Exception {
+	                return rados.rados_aio_create_completion(callbackContext, callbackComplete, callbackSafe, pointerByReference);
+	            }
+	        },
+	        "Failed to create completion"
+	    );
+        pointer = pointerByReference.getValue();
+	}
+	
+	/**
+	 * Block until the operation completes.  This means it is in memory on all replicas.
+	 * @throws RadosException
+	 */
+	public void waitForComplete() throws RadosException {
+        handleReturnCode(new Callable<Integer>() {
+	        	@Override
+	            public Integer call() throws Exception {
+	                return rados.rados_aio_wait_for_complete(getPointer());
+	            }
+	        },
+	        "Failed to wait for AIO completion"
+	    );		
+	}
+	
+    /**
+     * Release a completion
+     * <p>
+     * Call this when you no longer need the completion. It may not be freed immediately if the operation is not acked and committed.
+     */
+	@Override
+	public void close() throws IOException {
+		rados.rados_aio_release(getPointer());
+	}
+
+	public Pointer getPointer() {
+		return pointer;
+	}
+	
+	/* TODO
+	private static class CallbackHandler implements Callback {
+		CompletionCallback completionCallback;
+		
+		public void callback(Pointer completion, Pointer callbackContext) {
+			completionCallback.callback(completion, callbackContext);
+		}
+	}
+
+	public static interface CompletionCallback {
+		public void callback(Completion completion, Pointer callbackContext);
+	}
+	*/
+}

--- a/src/main/java/com/ceph/rados/Completion.java
+++ b/src/main/java/com/ceph/rados/Completion.java
@@ -27,9 +27,9 @@ public class Completion extends RadosBase implements Closeable {
 			synchronized (completionMap) {
 				completion = completionMap.get(completionId);
 			}
-			if (completion == null)
-				throw new RadosException("Failed to executed onComplete() due to unknown completionId: " + completionId);
-			else
+			
+			// If the completion has not been closed yet, call the handler.
+			if (completion != null)
 				completion.onComplete();
 		}
 	};
@@ -41,9 +41,9 @@ public class Completion extends RadosBase implements Closeable {
 			synchronized (completionMap) {
 				completion = completionMap.get(completionId);
 			}
-			if (completion == null)
-				throw new RadosException("Failed to executed onSafe() due to unknown completionId: " + completionId);
-			else
+
+			// If the completion has not been closed yet, call the handler.
+			if (completion != null)
 				completion.onSafe();
 		}
 	};
@@ -69,7 +69,7 @@ public class Completion extends RadosBase implements Closeable {
 		super();
         final PointerByReference pointerByReference = new PointerByReference();
 		if (notifyOnComplete || notifyOnSafe) {
-			// Record this object in the global completion map so that is can be accessed from the callback handlers. 
+			// Record this object in the global completion map so that it can be accessed from the callback handlers. 
 			synchronized (completionMap) {
 				completionId = nextCompletionId++;
 				if (completionId <= 0) {

--- a/src/main/java/com/ceph/rados/Completion.java
+++ b/src/main/java/com/ceph/rados/Completion.java
@@ -26,7 +26,7 @@ public class Completion extends RadosBase implements Closeable {
 	private static Callback completeCallback = new Callback() {
 		@SuppressWarnings("unused")
 		public void callback(Pointer completionPointer, Pointer callbackContext) throws RadosException {
-			final int completionId = callbackContext.getInt(0);
+			final int completionId = (int)Pointer.nativeValue(callbackContext);
 			Completion completion;
 			synchronized (completionMap) {
 				completion = completionMap.get(completionId);
@@ -42,7 +42,7 @@ public class Completion extends RadosBase implements Closeable {
 	private static Callback safeCallback = new Callback() {
 		@SuppressWarnings("unused")
 		public void callback(Pointer completionPointer, Pointer callbackContext) throws RadosException {
-			final int completionId = callbackContext.getInt(0);
+			final int completionId = (int)Pointer.nativeValue(callbackContext);
 			Completion completion;
 			synchronized (completionMap) {
 				completion = completionMap.get(completionId);
@@ -97,7 +97,7 @@ public class Completion extends RadosBase implements Closeable {
 					@Override
 					public Integer call() throws Exception {
 						return rados.rados_aio_create_completion(
-								Pointer.createConstant(completionId), 
+								Pointer.createConstant((long)completionId), 
 								notifyOnComplete?completeCallback:null, 
 								notifyOnSafe?safeCallback:null,
 								pointerByReference

--- a/src/main/java/com/ceph/rados/IoCTX.java
+++ b/src/main/java/com/ceph/rados/IoCTX.java
@@ -76,7 +76,7 @@ public class IoCTX extends RadosBase implements Closeable {
      * @param namespace The name to use as the namespace, or NULL use the default namespace.
      */
     public void setNamespace(String namespace) {
-    	rados.rados_ioctx_set_namespace(getPointer(), namespace);
+        rados.rados_ioctx_set_namespace(getPointer(), namespace);
     }
     
     /**
@@ -809,8 +809,8 @@ public class IoCTX extends RadosBase implements Closeable {
         return attr_map;
     }
 
-	@Override
-	public void close() throws IOException {
+    @Override
+    public void close() throws IOException {
         rados.rados_ioctx_destroy(getPointer());
-	}
+    }
 }

--- a/src/main/java/com/ceph/rados/IoCTX.java
+++ b/src/main/java/com/ceph/rados/IoCTX.java
@@ -69,6 +69,17 @@ public class IoCTX extends RadosBase implements Closeable {
     }
 
     /**
+     * Set the namespace for objects within an IO context.
+     * <p>
+     * The namespace specification further refines a pool into different domains. The mapping of objects to PGs is also based on this value.
+     * 
+     * @param namespace The name to use as the namespace, or NULL use the default namespace.
+     */
+    public void setNamespace(String namespace) {
+    	rados.rados_ioctx_set_namespace(getPointer(), namespace);
+    }
+    
+    /**
      * Get the pool ID of this context
      *
      * @return long

--- a/src/main/java/com/ceph/rados/IoCTX.java
+++ b/src/main/java/com/ceph/rados/IoCTX.java
@@ -267,6 +267,103 @@ public class IoCTX extends RadosBase {
     }
 
     /**
+     * Asynchronously write to an object
+     *
+     * @param oid
+     *          The object to write to
+     * @param completion
+     *          The completion instructions
+     * @param buf
+     *          The content to write
+     * @param offset
+     *          The offset when writing
+     * @throws RadosException
+     */
+    public void aioWrite(final String oid, final Completion completion, final byte[] buf, final long offset) throws RadosException, IllegalArgumentException {
+        if (offset < 0) {
+            throw new IllegalArgumentException("Offset shouldn't be a negative value");
+        }
+        handleReturnCode(new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                return rados.rados_aio_write(getPointer(), oid, completion.getPointer(), buf, buf.length, offset);
+            }
+        }, "Failed AIO writing %s bytes with offset %s to %s", buf.length, offset, oid);
+    }
+
+    /**
+     * Asynchronously write to an object without an offset
+     *
+     * @param oid
+     *          The object to write to
+     * @param completion
+     *          The completion instructions
+     * @param buf
+     *          The content to write
+     * @throws RadosException
+     */
+    public void aioWrite(String oid, final Completion completion, byte[] buf) throws RadosException {
+        this.aioWriteFull(oid, completion, buf, buf.length);
+    }
+
+    /**
+     * Asynchronously write an entire object
+     * The object is filled with the provided data. If the object exists, it is atomically truncated and then written.
+     *
+     * @param oid
+     *          The object to write to
+     * @param completion
+     *          The completion instructions
+     * @param buf
+     *          The content to write
+     * @param len
+     *          The length of the data to write
+     * @throws RadosException
+     */
+    public void aioWriteFull(final String oid, final Completion completion, final byte[] buf, final int len) throws RadosException {
+        handleReturnCode(new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+            	synchronized (IoCTX.class) {	// TODO
+            		return rados.rados_aio_write_full(getPointer(), oid, completion.getPointer(), buf, len);
+            	}
+            }
+        }, "Failed to AIO write %s bytes to %s", len, oid);
+    }
+
+    /**
+     * Asynchronously write to an object without an offset
+     *
+     * @param oid
+     *          The object to write to
+     * @param completion
+     *          The completion instructions
+     * @param buf
+     *          The content to write
+     * @param offset
+     *          The offset when writing
+     * @throws RadosException
+     */
+    public void aioWrite(String oid, final Completion completion, String buf, long offset) throws RadosException {
+        this.aioWrite(oid, completion, buf.getBytes(), offset);
+    }
+
+    /**
+     * Asynchronously write to an object without an offset
+     *
+     * @param oid
+     *          The object to write to
+     * @param completion
+     *          The completion instructions
+     * @param buf
+     *          The content to write
+     * @throws RadosException
+     */
+    public void aioWrite(String oid, final Completion completion, String buf) throws RadosException {
+        this.aioWrite(oid, completion, buf.getBytes());
+    }
+    
+    /**
      * Remove an object
      *
      * @param oid

--- a/src/main/java/com/ceph/rados/IoCTX.java
+++ b/src/main/java/com/ceph/rados/IoCTX.java
@@ -21,6 +21,8 @@ package com.ceph.rados;
 
 import static com.ceph.rados.Library.rados;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -37,7 +39,7 @@ import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.LongByReference;
 import com.sun.jna.ptr.PointerByReference;
 
-public class IoCTX extends RadosBase {
+public class IoCTX extends RadosBase implements Closeable {
 
     private static final int    EXT_ATTR_MAX_LEN = 4096;
 
@@ -324,9 +326,7 @@ public class IoCTX extends RadosBase {
         handleReturnCode(new Callable<Integer>() {
             @Override
             public Integer call() throws Exception {
-            	synchronized (IoCTX.class) {	// TODO
-            		return rados.rados_aio_write_full(getPointer(), oid, completion.getPointer(), buf, len);
-            	}
+            	return rados.rados_aio_write_full(getPointer(), oid, completion.getPointer(), buf, len);
             }
         }, "Failed to AIO write %s bytes to %s", len, oid);
     }
@@ -782,4 +782,9 @@ public class IoCTX extends RadosBase {
 
         return attr_map;
     }
+
+	@Override
+	public void close() throws IOException {
+        rados.rados_ioctx_destroy(getPointer());
+	}
 }

--- a/src/main/java/com/ceph/rados/IoCTX.java
+++ b/src/main/java/com/ceph/rados/IoCTX.java
@@ -364,6 +364,21 @@ public class IoCTX extends RadosBase implements Closeable {
     }
     
     /**
+     * Block until all pending writes in an io context are safe.
+     * <p>
+     * This is not equivalent to calling rados_aio_wait_for_safe() on all write completions, since this waits for the associated callbacks to complete as well.
+     * @throws RadosException
+     */
+    public void aioFlush() throws RadosException {
+        handleReturnCode(new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+            	return rados.rados_aio_flush(getPointer());
+            }
+        }, "Failed to AIO flush");
+    }
+
+    /**
      * Remove an object
      *
      * @param oid

--- a/src/main/java/com/ceph/rados/jna/Rados.java
+++ b/src/main/java/com/ceph/rados/jna/Rados.java
@@ -84,6 +84,7 @@ public interface Rados extends Library {
     // Asynchronous I/O
     int rados_aio_create_completion(Pointer callbackContext, Callback callbackComplete, Callback callbackSafe, PointerByReference completion);
     void rados_aio_release(Pointer completion);
+    int rados_aio_flush(Pointer completion);
     int rados_aio_write(Pointer ioctx, String oid, Pointer completion, byte[] buffer, int length, long offset);
     int rados_aio_write_full(Pointer ioctx, String oid, Pointer completion, byte[] buffer, int length);
     int rados_aio_wait_for_complete(Pointer completion);

--- a/src/main/java/com/ceph/rados/jna/Rados.java
+++ b/src/main/java/com/ceph/rados/jna/Rados.java
@@ -89,35 +89,6 @@ public interface Rados extends Library {
     int rados_aio_write(Pointer ioctx, String oid, Pointer completion, byte[] buffer, int length, long offset);
     int rados_aio_write_full(Pointer ioctx, String oid, Pointer completion, byte[] buffer, int length);
     int rados_aio_wait_for_complete(Pointer completion);
-
-    /* TODO
-000000000006eee0 T rados_aio_append
-000000000006a680 T rados_aio_cancel
-000000000006f5c0 T *rados_aio_create_completion
-000000000006a420 T rados_aio_flush
-000000000006a360 T rados_aio_flush_async
-0000000000069eb0 T rados_aio_get_return_value
-0000000000069750 T rados_aio_is_complete
-0000000000069cf0 T rados_aio_is_complete_and_cb
-0000000000069820 T rados_aio_is_safe
-0000000000069dd0 T rados_aio_is_safe_and_cb
-000000000006f300 T rados_aio_notify
-000000000006a050 T rados_aio_read
-000000000006bd90 T rados_aio_read_op_operate
-000000000006d570 T *rados_aio_release
-000000000006a200 T rados_aio_remove
-000000000006a4e0 T rados_aio_stat
-000000000006ad90 T rados_aio_unwatch
-0000000000069350 T rados_aio_wait_for_complete
-00000000000698f0 T rados_aio_wait_for_complete_and_cb
-0000000000069550 T rados_aio_wait_for_safe
-0000000000069af0 T rados_aio_wait_for_safe_and_cb
-000000000006a9f0 T rados_aio_watch
-000000000006b000 T rados_aio_watch_flush
-000000000006ecb0 T *rados_aio_write
-000000000006eaa0 T *rados_aio_write_full
-000000000006b740 T rados_aio_write_op_operate
-     */
     
     // read, write, remove, iterate extended attributes
     int rados_getxattr(Pointer ioctx, String oid, String xattrName, byte[] buf, long len);

--- a/src/main/java/com/ceph/rados/jna/Rados.java
+++ b/src/main/java/com/ceph/rados/jna/Rados.java
@@ -20,6 +20,7 @@ package com.ceph.rados.jna;
 
 import java.nio.ByteBuffer;
 
+import com.sun.jna.Callback;
 import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
@@ -80,6 +81,42 @@ public interface Rados extends Library {
     int rados_read_op_operate(Pointer read_op, Pointer ioctx, String oid, int flags);
     int rados_shutdown(Pointer cluster);
 
+    // Asynchronous I/O
+    int rados_aio_create_completion(Pointer callbackContext, Callback callbackComplete, Callback callbackSafe, PointerByReference completion);
+    void rados_aio_release(Pointer completion);
+    int rados_aio_write(Pointer ioctx, String oid, Pointer completion, byte[] buffer, int length, long offset);
+    int rados_aio_write_full(Pointer ioctx, String oid, Pointer completion, byte[] buffer, int length);
+    int rados_aio_wait_for_complete(Pointer completion);
+
+    /* TODO
+000000000006eee0 T rados_aio_append
+000000000006a680 T rados_aio_cancel
+000000000006f5c0 T *rados_aio_create_completion
+000000000006a420 T rados_aio_flush
+000000000006a360 T rados_aio_flush_async
+0000000000069eb0 T rados_aio_get_return_value
+0000000000069750 T rados_aio_is_complete
+0000000000069cf0 T rados_aio_is_complete_and_cb
+0000000000069820 T rados_aio_is_safe
+0000000000069dd0 T rados_aio_is_safe_and_cb
+000000000006f300 T rados_aio_notify
+000000000006a050 T rados_aio_read
+000000000006bd90 T rados_aio_read_op_operate
+000000000006d570 T *rados_aio_release
+000000000006a200 T rados_aio_remove
+000000000006a4e0 T rados_aio_stat
+000000000006ad90 T rados_aio_unwatch
+0000000000069350 T rados_aio_wait_for_complete
+00000000000698f0 T rados_aio_wait_for_complete_and_cb
+0000000000069550 T rados_aio_wait_for_safe
+0000000000069af0 T rados_aio_wait_for_safe_and_cb
+000000000006a9f0 T rados_aio_watch
+000000000006b000 T rados_aio_watch_flush
+000000000006ecb0 T *rados_aio_write
+000000000006eaa0 T *rados_aio_write_full
+000000000006b740 T rados_aio_write_op_operate
+     */
+    
     // read, write, remove, iterate extended attributes
     int rados_getxattr(Pointer ioctx, String oid, String xattrName, byte[] buf, long len);
     int rados_setxattr(Pointer ioctx, String oid, String xattrName, byte[] buf, long len);

--- a/src/main/java/com/ceph/rados/jna/Rados.java
+++ b/src/main/java/com/ceph/rados/jna/Rados.java
@@ -53,6 +53,7 @@ public interface Rados extends Library {
     long rados_get_instance_id(Pointer cluster);
     int rados_ioctx_create(Pointer cluster, String pool, Pointer ioctx);
     void rados_ioctx_destroy(Pointer ioctx);
+    void rados_ioctx_set_namespace(Pointer ioctx, String namespace);
     long rados_ioctx_get_id(Pointer ioctx);
     int rados_ioctx_pool_set_auid(Pointer ioctx, long auid);
     int rados_ioctx_pool_get_auid(Pointer ioctx, LongByReference auid);


### PR DESCRIPTION
Hello @wido ,

I promised you a Pull request some time ago for some miscellaneous librados support.

I created a Completion class to support Completion objects in general, and then implemented support for AIO writes.  No AIO read support as of yet.

I also added support setting the IOCtx namespace.

Lastly, I added a Maven option to suppress unit tests in case the user does not have a Ceph test cluster available to their build machine. 

This code has been tested on our Ceph cluster and has been running in our production environment.

Thanks,

Dan Jakubiec
