### PR TITLE
RadosStriper: define write() with length as param

### DIFF
--- a/src/main/java/com/ceph/radosstriper/IoCTXStriper.java
+++ b/src/main/java/com/ceph/radosstriper/IoCTXStriper.java
@@ -64,19 +64,35 @@ public class IoCTXStriper extends RadosBase {
      *
      * @param oid    The object to write to
      * @param buf    The content to write
+     * @param length The length to write
      * @param offset The offset when writing
      * @throws RadosException
      */
-    public void write(final String oid, final byte[] buf, final long offset) throws RadosException, IllegalArgumentException {
+    public void write(final String oid, final byte[] buf, final int length, final long offset) throws RadosException, IllegalArgumentException {
         if (offset < 0) {
             throw new IllegalArgumentException("Offset shouldn't be a negative value");
+        }
+        if (buf.length < length) {
+            throw new IllegalArgumentException("Length shouldn't be a smaller than Buffer length");
         }
         handleReturnCode(new Callable<Integer>() {
             @Override
             public Integer call() throws Exception {
-                return rados.rados_striper_write(getPointer(), oid, buf, buf.length, offset);
+                return rados.rados_striper_write(getPointer(), oid, buf, length, offset);
             }
-        }, "Failed writing %s bytes with offset %s to %s", buf.length, offset, oid);
+        }, "Failed writing %s bytes with offset %s to %s", length, offset, oid);
+    }
+
+    /**
+     * Write to an object
+     *
+     * @param oid    The object to write to
+     * @param buf    The content to write
+     * @param offset The offset when writing
+     * @throws RadosException
+     */
+    public void write(final String oid, final byte[] buf, final long offset) throws RadosException, IllegalArgumentException {
+        this.write(oid, buf, buf.length, offset);
     }
 
     /**

--- a/src/test/java/com/ceph/radosstriper/TestRadosStriper.java
+++ b/src/test/java/com/ceph/radosstriper/TestRadosStriper.java
@@ -149,5 +149,26 @@ public class TestRadosStriper {
         }
     }
 
+    /**
+     * This test tests write of partial buffer
+     */
+    @Test
+    public void testIoCtxWritePartialBuffer() throws Exception {
+        /**
+         * The object we will write to with the data
+         */
+        String oid = "rados-java-partial";
+        int write_len = 5;
+        byte[] content = "junit wrote this".getBytes();
+
+        ioctx.write(oid, content, write_len, 0);
+
+        /**
+         * We now check for expected size
+         */
+        assertEquals("The size doesn't match length param", write_len, ioctx.stat(oid).getSize());
+
+        ioctx.remove(oid);
+    }
 
 }


### PR DESCRIPTION
There are cases when we may want to pass length parameter to write()
call - e.g. we were reading to byte[] and received not full buffer back
from stream.