### PR TITLE
Reinstate change to LongByReference for listChildren

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ you can use them on any system where JNA and librados are present.
 ## Building
 
 ```bash
-$ mvn clean install (-DskipTests)
+$ mvn clean install (-Dcom.ceph.rados.skipTests)
 ```
 
 ## Tests

--- a/src/main/java/com/ceph/rbd/RbdImage.java
+++ b/src/main/java/com/ceph/rbd/RbdImage.java
@@ -328,15 +328,15 @@ public class RbdImage {
 			int initialBufferSize = 1024;
             int childCount;
 
-			IntByReference poolBufferSize = new IntByReference(initialBufferSize);
-			IntByReference imageBufferSize = new IntByReference(initialBufferSize);
+			LongByReference poolBufferSize = new LongByReference(initialBufferSize);
+			LongByReference imageBufferSize = new LongByReference(initialBufferSize);
 
 			byte pools[];
 			byte images[];
 
             do {
-                pools = new byte[poolBufferSize.getValue()];
-                images = new byte[imageBufferSize.getValue()];
+                pools = new byte[(int) poolBufferSize.getValue()];
+                images = new byte[(int) imageBufferSize.getValue()];
                 childCount = rbd.rbd_list_children(this.getPointer(), pools, poolBufferSize, images, imageBufferSize);
                 // -34 (-ERANGE) is returned if the byte buffers are not big enough
             } while (childCount == -34);

--- a/src/main/java/com/ceph/rbd/jna/Rbd.java
+++ b/src/main/java/com/ceph/rbd/jna/Rbd.java
@@ -59,5 +59,5 @@ public interface Rbd extends Library {
     int rbd_resize(Pointer source_image, long size);
     int rbd_flatten(Pointer image);
     int rbd_snap_set(Pointer image, String snapname);
-    int rbd_list_children(Pointer image, byte[] pools, IntByReference pools_len, byte[] images, IntByReference images_len);
+    int rbd_list_children(Pointer image, byte[] pools, LongByReference pools_len, byte[] images, LongByReference images_len);
 }

--- a/src/test/java/com/ceph/rados/TestRados.java
+++ b/src/test/java/com/ceph/rados/TestRados.java
@@ -65,6 +65,10 @@ public final class TestRados {
         rados.confReadFile(new File(CONFIG_FILE));
         rados.connect();
         ioctx = rados.ioCtxCreate(POOL);
+        String [] allOids = ioctx.listObjects();
+        for (int i = 0; i < allOids.length; i++) {
+          ioctx.remove(allOids[i]);
+        }
     }
 
     @AfterClass
@@ -405,21 +409,20 @@ public final class TestRados {
         /**
          * The object we will write to with the data
          */
-        Rados r = null;
-        IoCTX io = null;
         String oid = "rados-java_item_";
         String content = "junit wrote this ";
         int nb = 100;
 
         try {
             System.out.println("Start");
+            String [] allOids = ioctx.listObjects();
             for (int i = 0; i < nb; i++) {
                 byte []bytes = (content + i).getBytes();
                 ioctx.writeFull(oid+i, bytes, bytes.length);
             }
 
-            String [] allOids = ioctx.listObjects();
-            assertTrue("Global number of items should be " + nb, allOids.length == nb);
+            allOids = ioctx.listObjects();
+            assertTrue("Global number of items should be " + nb + ", but is " + allOids.length, allOids.length == nb);
 
             // Check reading all items in 10 parts
             ListCtx listCtx = ioctx.listObjectsPartial(nb/10);
@@ -473,11 +476,9 @@ public final class TestRados {
         }
         finally {
             try {
-                if(r != null) {
-                    if(ioctx != null) {
-                        for (int i = 0; i < nb; i++) {
-                            ioctx.remove(oid+i);
-                        }
+                if(ioctx != null) {
+                    for (int i = 0; i < nb; i++) {
+                        ioctx.remove(oid+i);
                     }
                 }
             }

--- a/src/test/java/com/ceph/rbd/TestRbd.java
+++ b/src/test/java/com/ceph/rbd/TestRbd.java
@@ -76,6 +76,10 @@ public final class TestRbd {
         rados.confReadFile(new File(CONFIG_FILE));
         rados.connect();
         ioctx = rados.ioCtxCreate(POOL);
+        String [] allOids = ioctx.listObjects();
+        for (int i = 0; i < allOids.length; i++) {
+            ioctx.remove(allOids[i]);
+        }
     }
 
     @AfterClass


### PR DESCRIPTION
Hello @wido ,
Pull requests https://github.com/ceph/rados-java/pull/9 and https://github.com/ceph/rados-java/pull/11 by my colleague @nightfurys changed how children of snapshots are listed, to use LongByReference. This resolved a seg fault due to a mismatch between int sizes from Java to C++. 
In Sep 2015, you changed this back to using IntByReference. Due to other changes in rados-java or ceph, the original symptom did not re-appear, but the problem now exists again in a more hidden fashion.
This pull request fixes the issue.

To reproduce the problem, increase the childCount from 3 to 82 in TestRbd#testListChildren. With the existing code, you'll get a coredump. With these fixes, you won't. I have not made this change to the unit test since it lengthens the test scope and runtime, but it could be changed if desired.

Note that if you change the childCount to 80 or 81, you will see errors about childImage9 not listed as a child, a symptom of verging on the threshold of failure. This threshold depends on (name length * number of children). For example, changing the name to "childImagechildImagechildImagechildImagechildImage" (50 chars) causes it to fail with 20 children.
The imageSize does not matter.

In addition:
- a correction to a mvn command in README.md
- a unit test change to clean up objects after tests complete, and objects that may be left over from previous runs, before tests start. This allows repeated runs of unit tests to pass, which they were not.

Thanks in advance. I'll watch for any comments here.