### PR TITLE
Added support for Completion.waitForSafe().

### DIFF
--- a/src/main/java/com/ceph/rados/Completion.java
+++ b/src/main/java/com/ceph/rados/Completion.java
@@ -134,6 +134,21 @@ public class Completion extends RadosBase implements Closeable {
     }
 
     /**
+     * Block until the operation is safe. This means it is on stable storage on all
+     * replicas.
+     * 
+     * @throws RadosException
+     */
+    public void waitForSafe() throws RadosException {
+        handleReturnCode(new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                return rados.rados_aio_wait_for_safe(getPointer());
+            }
+        }, "Failed to wait for AIO safe");
+    }
+
+    /**
      * Override this function to implement callback handling. If notifyOnSafe is
      * true, this function is called when the operation is in memory on all
      * replicas.

--- a/src/main/java/com/ceph/rados/jna/Rados.java
+++ b/src/main/java/com/ceph/rados/jna/Rados.java
@@ -89,6 +89,7 @@ public interface Rados extends Library {
     int rados_aio_write(Pointer ioctx, String oid, Pointer completion, byte[] buffer, int length, long offset);
     int rados_aio_write_full(Pointer ioctx, String oid, Pointer completion, byte[] buffer, int length);
     int rados_aio_wait_for_complete(Pointer completion);
+    int rados_aio_wait_for_safe(Pointer completion);
     
     // read, write, remove, iterate extended attributes
     int rados_getxattr(Pointer ioctx, String oid, String xattrName, byte[] buf, long len);


### PR DESCRIPTION
"Wait for safe" support added to Completion objects. Previously only "wait for complete" was supported.

Resubmitted pull request with single-commit.