### PR TITLE
fix executeXxxCommand memory leak

### DIFF
--- a/src/main/java/com/ceph/rados/Rados.java
+++ b/src/main/java/com/ceph/rados/Rados.java
@@ -438,6 +438,8 @@ public class Rados extends RadosBase {
 
         final String out = (outBuf.getValue() == null ? "" : new String(outBuf.getValue().getByteArray(0, outBufLen.getValue())));
 
+        bufferFree(outBuf.getValue());
+
         return new RadosCommandResult(out, status);
     }
 
@@ -467,6 +469,8 @@ public class Rados extends RadosBase {
 
         final String out = (outBuf.getValue() == null ? "" : new String(outBuf.getValue().getByteArray(0, outBufLen.getValue())));
 
+        bufferFree(outBuf.getValue());
+
         return new RadosCommandResult(out, status);
     }
 
@@ -495,6 +499,8 @@ public class Rados extends RadosBase {
             throw new RadosException("Error when executing Rados osd command: " + status, r);
 
         final String out = (outBuf.getValue() == null ? "" : new String(outBuf.getValue().getByteArray(0, outBufLen.getValue())));
+
+        bufferFree(outBuf.getValue());
 
         return new RadosCommandResult(out, status);
     }
@@ -529,5 +535,17 @@ public class Rados extends RadosBase {
         public String getStatus() {
             return statusOutput;
         }
+    }
+
+    /**
+     * free a rados-allocated buffer
+     *
+     * Release memory allocated by librados calls like rados_mon_command().
+     *
+     * @param buf buffer pointer
+     */
+    public void bufferFree(final Pointer buf) {
+        rados.rados_buffer_free(buf);
+        return;
     }
 }

--- a/src/main/java/com/ceph/rados/jna/Rados.java
+++ b/src/main/java/com/ceph/rados/jna/Rados.java
@@ -103,4 +103,6 @@ public interface Rados extends Library {
     int rados_mon_command(Pointer cluster, String[] cmd, int cmdLen, String inbuf, int inbufLen, PointerByReference outBuf, IntByReference outBufLen, PointerByReference statusBuf, IntByReference statusBufLen);
     int rados_mon_command_target(Pointer cluster, String target, String[] cmd, int cmdLen, String inbuf, int inbufLen, PointerByReference outBuf, IntByReference outBufLen, PointerByReference statusBuf, IntByReference statusBufLen);
     int rados_osd_command(Pointer cluster, int osdId, String[] cmd, int cmdLen, String inbuf, int inbufLen, PointerByReference outBuf, IntByReference outBufLen, PointerByReference statusBuf, IntByReference statusBufLen);
+
+    void rados_buffer_free(Pointer buf);
 }


### PR DESCRIPTION
as the [api](https://github.com/ceph/ceph/blob/master/src/include/rados/librados.h#L3624) specified, the caller is responsible of freeing the buffer.