### PR TITLE
Add support for both constructors in RadosStriper.

### DIFF
--- a/src/main/java/com/ceph/radosstriper/RadosStriper.java
+++ b/src/main/java/com/ceph/radosstriper/RadosStriper.java
@@ -34,6 +34,10 @@ public class RadosStriper extends Rados {
         super(id);
     }
 
+    public RadosStriper(String clustername, String name, long flags) {
+        super(clustername, name, flags);
+    }
+
     public IoCTXStriper ioCtxCreateStriper(final IoCTX ioCTX) throws RadosException {
         final Pointer p = new Memory(Pointer.SIZE);
         handleReturnCode(new Callable<Integer>() {


### PR DESCRIPTION
We have a use case for a cluster of a different name as we test our own Ceph cluster.