### PR TITLE
Update Rados.java

### DIFF
--- a/src/main/java/com/ceph/rados/Rados.java
+++ b/src/main/java/com/ceph/rados/Rados.java
@@ -359,7 +359,7 @@ public class Rados extends RadosBase {
      * @throws RadosException
      */
     public IoCTX ioCtxCreate(final String pool) throws RadosException {
-        final Pointer p = new Memory(Pointer.SIZE);
+        final Pointer p = new Memory(Native.POINTER_SIZE);
         handleReturnCode(new Callable<Integer>() {
             @Override
             public Integer call() throws Exception {


### PR DESCRIPTION
jna 5.0.0 removed the Pointer#SIZE

here is the release doc:
[https://github.com/java-native-access/jna/blob/master/CHANGES.md](https://github.com/java-native-access/jna/blob/master/CHANGES.md)

> com.sun.jna.Pointer#SIZE is removed. Its use is replaced by com.sun.jna.Native#POINTER_SIZE to prevent a class loading deadlock, when JNA is initialized from multiple threads