### PR TITLE
jna: use Native.POINTER_SIZE

### DIFF
--- a/src/main/java/com/ceph/rados/IoCTX.java
+++ b/src/main/java/com/ceph/rados/IoCTX.java
@@ -157,9 +157,9 @@ public class IoCTX extends RadosBase implements Closeable {
      * @throws RadosException
      */
     public String[] listObjects() throws RadosException {
-        Pointer entry = new Memory(Pointer.SIZE);
+        Pointer entry = new Memory(Native.POINTER_SIZE);
         List<String> objects = new ArrayList<String>();
-        final Pointer list = new Memory(Pointer.SIZE);
+        final Pointer list = new Memory(Native.POINTER_SIZE);
 
         handleReturnCode(new Callable<Integer>() {
             @Override
@@ -185,7 +185,7 @@ public class IoCTX extends RadosBase implements Closeable {
      * @throws RadosException
      */
     public ListCtx listObjectsPartial(int limit) throws RadosException {
-        Pointer list = new Memory(Pointer.SIZE);
+        Pointer list = new Memory(Native.POINTER_SIZE);
 
         int r = rados.rados_nobjects_list_open(this.getPointer(), list);
         if (r < 0) {
@@ -782,7 +782,7 @@ public class IoCTX extends RadosBase implements Closeable {
      */
     public Map<String, String> getExtendedAttributes(final String oid) throws RadosException {
         Map<String, String> attr_map = new HashMap<>();
-        final Pointer iterator = new Memory(Pointer.SIZE);
+        final Pointer iterator = new Memory(Native.POINTER_SIZE);
         final PointerByReference attr_name = new PointerByReference();
         final PointerByReference attr_value = new PointerByReference();
         final IntByReference attr_value_len = new IntByReference();

--- a/src/main/java/com/ceph/rados/ListCtx.java
+++ b/src/main/java/com/ceph/rados/ListCtx.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import com.ceph.rados.exceptions.RadosException;
 
 import com.sun.jna.Memory;
+import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 
 import static com.ceph.rados.Library.rados;
@@ -57,7 +58,7 @@ public class ListCtx {
         if (list == null) {
             return 0;
         }
-        Pointer entry = new Memory(Pointer.SIZE);
+        Pointer entry = new Memory(Native.POINTER_SIZE);
         int i = 0;
         while (i < limit && rados.rados_nobjects_list_next(list.getPointer(0), entry, null, null) == 0) {
             ids[i] = entry.getPointer(0).getString(0);
@@ -82,7 +83,7 @@ public class ListCtx {
         if (list == null) {
             return 0;
         }
-        Pointer entry = new Memory(Pointer.SIZE);
+        Pointer entry = new Memory(Native.POINTER_SIZE);
         long j = 0;
         while (j < skip && rados.rados_nobjects_list_next(list.getPointer(0), entry, null, null) == 0) {
             j++;

--- a/src/main/java/com/ceph/radosstriper/RadosStriper.java
+++ b/src/main/java/com/ceph/radosstriper/RadosStriper.java
@@ -23,6 +23,7 @@ import com.ceph.rados.Rados;
 import com.ceph.rados.exceptions.RadosException;
 import static com.ceph.radosstriper.Library.rados;
 import com.sun.jna.Memory;
+import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 
 import java.util.concurrent.Callable;
@@ -39,7 +40,7 @@ public class RadosStriper extends Rados {
     }
 
     public IoCTXStriper ioCtxCreateStriper(final IoCTX ioCTX) throws RadosException {
-        final Pointer p = new Memory(Pointer.SIZE);
+        final Pointer p = new Memory(Native.POINTER_SIZE);
         handleReturnCode(new Callable<Integer>() {
             @Override
             public Integer call() throws Exception {

--- a/src/main/java/com/ceph/rbd/Rbd.java
+++ b/src/main/java/com/ceph/rbd/Rbd.java
@@ -237,7 +237,7 @@ public class Rbd {
      * @return RbdImage
      */
     public RbdImage open(String name, String snapName) throws RbdException {
-        Pointer p = new Memory(Pointer.SIZE);
+        Pointer p = new Memory(Native.POINTER_SIZE);
         int r = rbd.rbd_open(this.io, name, p, snapName);
         if (r < 0) {
             throw new RbdException("Failed to open image " + name, r);
@@ -268,7 +268,7 @@ public class Rbd {
      * @return RbdImage
      */
     public RbdImage openReadOnly(String name, String snapName) throws RbdException {
-        Pointer p = new Memory(Pointer.SIZE);
+        Pointer p = new Memory(Native.POINTER_SIZE);
         int r = rbd.rbd_open_read_only(this.io, name, p, snapName);
         if (r < 0) {
             throw new RbdException("Failed to open image " + name, r);


### PR DESCRIPTION
Following d59c6e5c499fffb0d5a62b0abdb7d1963992331e this uses
Native.POINTER_SIZE throughout the codebase. Fixes issue discovered
while testing Ceph Octopus with CloudStack master with jna 5.x:
https://github.com/apache/cloudstack/issues/4159

cc @wido 