### PR TITLE
fix incorrect radosstriper jna bindings

### DIFF
--- a/src/main/java/com/ceph/radosstriper/IoCTXStriper.java
+++ b/src/main/java/com/ceph/radosstriper/IoCTXStriper.java
@@ -137,7 +137,7 @@ public class IoCTXStriper extends RadosBase implements AutoCloseable {
         return handleReturnCode(new Callable<Integer>() {
             @Override
             public Integer call() throws Exception {
-                return rados.rados_set_object_layout_stripe_unit(getPointer(), stripeUnit);
+                return rados.rados_striper_set_object_layout_stripe_unit(getPointer(), stripeUnit);
             }
         }, "Failed to set stripe unit to: %s", stripeUnit);
     }
@@ -154,7 +154,7 @@ public class IoCTXStriper extends RadosBase implements AutoCloseable {
         return handleReturnCode(new Callable<Integer>() {
             @Override
             public Integer call() throws Exception {
-                return rados.rados_set_object_layout_stripe_count(getPointer(), stripeCount);
+                return rados.rados_striper_set_object_layout_stripe_count(getPointer(), stripeCount);
             }
         }, "Failed to set stripe count to: %s", stripeCount);
     }
@@ -171,7 +171,7 @@ public class IoCTXStriper extends RadosBase implements AutoCloseable {
         return handleReturnCode(new Callable<Integer>() {
             @Override
             public Integer call() throws Exception {
-                return rados.rados_set_object_layout_object_size(getPointer(), stripeObjectSize);
+                return rados.rados_striper_set_object_layout_object_size(getPointer(), stripeObjectSize);
             }
         }, "Failed to set stripe object size to: %s", stripeObjectSize);
     }

--- a/src/main/java/com/ceph/radosstriper/jna/RadosStriper.java
+++ b/src/main/java/com/ceph/radosstriper/jna/RadosStriper.java
@@ -31,11 +31,11 @@ public interface RadosStriper extends Library {
 
     void rados_striper_destroy(Pointer striper);
 
-    int rados_set_object_layout_stripe_unit(Pointer striper, int stripe_unit);
+    int rados_striper_set_object_layout_stripe_unit(Pointer striper, int stripe_unit);
 
-    int rados_set_object_layout_stripe_count(Pointer striper, int stripe_count);
+    int rados_striper_set_object_layout_stripe_count(Pointer striper, int stripe_count);
 
-    int rados_set_object_layout_object_size(Pointer striper, int object_size);
+    int rados_striper_set_object_layout_object_size(Pointer striper, int object_size);
 
     int rados_striper_write(Pointer striper, String oid, byte[] buf, int len, long off);
 


### PR DESCRIPTION
Fixes three radosstriper-specific jna bindings which are named incorrectly, and therefore do not match the functions provided by librados.
Without this, calling `IoCTXStriper.setStripeObjectSize()`, for example, throws an exception:

_Exception in thread "main" java.lang.UnsatisfiedLinkError: Error looking up function 'rados_set_object_layout_object_size': /usr/lib/x86_64-linux-gnu/libradosstriper.so.1: undefined symbol: rados_set_object_layout_object_size_
